### PR TITLE
Add docker-compose setup mirroring Gitpod configuration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,6 +3,15 @@ FROM gitpod/workspace-postgres
 RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh \
              && sdk install java 21.0.2-tem"
 
+# ensure required tools are available
+RUN sudo apt-get update \
+    && sudo apt-get install -y gnupg \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# configure java path for subsequent shells
+ENV JAVA_HOME=/home/gitpod/.sdkman/candidates/java/current
+ENV PATH="$JAVA_HOME/bin:$PATH"
+
 # disable angular analytics
 ENV NG_CLI_ANALYTICS=false
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,11 +29,14 @@ tasks:
       git clone --depth=1 -b 16.0 https://github.com/OCA/partner-contact
       git clone --depth=1 -b 16.0 https://github.com/OCA/web.git
       git clone --depth=1 -b 16.0 https://github.com/OpenEMS/odoo-openems.git
-      cd ../addons-enabled
+      cd ..
+      psql -h localhost -U postgres -c "CREATE USER odoo WITH PASSWORD 'odoo';" || true
+      psql -h localhost -U postgres -c "CREATE DATABASE prod OWNER odoo;" || true
+      cd addons-enabled
       ln -s ../addons-available/partner-contact/partner_firstname
       ln -s ../addons-available/web/web_m2x_options
       ln -s ../addons-available/odoo-openems/openems
-    command: odoo -d prod --addons-path=/workspace/odoo/addons-enabled -i base,partner_firstname,web_m2x_options,stock,openems
+    command: odoo -d prod --db_host=localhost --db_port=5432 --db_user=odoo --db_password=odoo --addons-path=/workspace/odoo/addons-enabled -i base,partner_firstname,web_m2x_options,stock,openems
 
 ports:
   - name: OpenEMS UI
@@ -60,7 +63,8 @@ ports:
     description: Cloud-side JSON/Websocket Api
     port: 8076
     onOpen: ignore
-  - name: OpenEMS Backend - Odoo XML-RPC Api
+  - name: PostgreSQL
+    description: Database used by Odoo
     port: 5432
     onOpen: ignore
   - name: OpenEMS Backend - Edge-Websocket

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,82 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: prod
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoo
+    ports:
+      - "5432:5432"
+
+  openems-backend:
+    build:
+      context: ..
+      dockerfile: .gitpod.Dockerfile
+    user: "0:0"
+    working_dir: /workspace/openems
+    command: >
+      bash -lc 'touch /tmp/.gradle-lock && ./gradlew build buildBackend -x test && rm /tmp/.gradle-lock &&
+      java -Dfelix.cm.dir=/workspace/openems/tools/gitpod/openems-backend/config.d -jar build/openems-backend.jar'
+    volumes:
+      - ..:/workspace/openems
+    ports:
+      - "8075:8075"
+      - "8076:8076"
+      - "8079:8079"
+      - "8081:8081"
+      - "8082:8082"
+
+  openems-edge:
+    build:
+      context: ..
+      dockerfile: .gitpod.Dockerfile
+    user: "0:0"
+    working_dir: /workspace/openems
+    command: >
+      bash -lc 'sleep 10 && while [ -f /tmp/.gradle-lock ]; do sleep 1; done && ./gradlew build buildEdge -x test &&
+      java -Dfelix.cm.dir=/workspace/openems/tools/gitpod/openems-edge/config.d
+      -Dopenems.data.dir=/workspace/openems/tools/gitpod/openems-edge/data -jar build/openems-edge.jar'
+    volumes:
+      - ..:/workspace/openems
+    ports:
+      - "8080:8080"
+      - "8084:8084"
+      - "8085:8085"
+
+  openems-ui:
+    build:
+      context: ..
+      dockerfile: .gitpod.Dockerfile
+    working_dir: /workspace/openems/ui
+    user: "0:0"
+    command: bash -lc 'npm install && ng serve -c openems-gitpod --host 0.0.0.0 --disable-host-check'
+    volumes:
+      - ..:/workspace/openems
+    ports:
+      - "4200:4200"
+
+  odoo:
+    build:
+      context: ..
+      dockerfile: .gitpod.Dockerfile
+    user: "0:0"
+    depends_on:
+      - postgres
+    command: >
+      bash -lc 'mkdir -p /workspace/odoo && cd /workspace/odoo &&
+      mkdir -p addons-available addons-enabled && cd addons-available &&
+      git clone --depth=1 -b 16.0 https://github.com/OCA/partner-contact &&
+      git clone --depth=1 -b 16.0 https://github.com/OCA/web.git &&
+      git clone --depth=1 -b 16.0 https://github.com/OpenEMS/odoo-openems.git &&
+      cd ../addons-enabled &&
+      ln -s ../addons-available/partner-contact/partner_firstname &&
+      ln -s ../addons-available/web/web_m2x_options &&
+      ln -s ../addons-available/odoo-openems/openems &&
+      odoo -d prod --db_host=postgres --db_port=5432 --db_user=odoo --db_password=odoo \
+      --addons-path=/workspace/odoo/addons-enabled -i base,partner_firstname,web_m2x_options,stock,openems'
+    volumes:
+      - ..:/workspace/openems
+    ports:
+      - "8069:8069"

--- a/gitpod-config.md
+++ b/gitpod-config.md
@@ -1,0 +1,13 @@
+# Gitpod Configuration
+
+This repository contains the following Gitpod-related configuration files and directories:
+
+- **.gitpod.Dockerfile** – Custom Gitpod workspace image based on `gitpod/workspace-postgres`; installs Java 21 with SDKMAN, Angular CLI, Odoo, and wkhtmltopdf. The base image provides a PostgreSQL server used by Odoo on port 5432.
+- **.gitpod.yml** – Defines Gitpod tasks for building and running the backend, edge, UI and Odoo services, and exposes required ports including the PostgreSQL database. The Odoo task creates an `odoo` user and `prod` database so credentials match the Docker Compose setup.
+- **tools/gitpod/** – Additional resources for Gitpod:
+  - `openems-backend/` – Dockerfile, configuration (`config.d`) and script to start the backend JAR.
+  - `openems-edge/` – Configuration (`config.d`) and data directory for the edge runtime.
+  - `openems-ui/` – Dockerfile and `nginx.conf` for serving the built UI.
+  - `README.md` – Directory overview.
+
+A Docker Compose definition mirroring this setup, including a separate PostgreSQL service for Odoo, is provided in `docker-compose/docker-compose.yml`.

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/MetadataOdoo.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/MetadataOdoo.java
@@ -215,10 +215,32 @@ public class MetadataOdoo extends AbstractMetadata implements AppCenterMetadata,
 		return this.getEdge(optEdgeId.get());
 	}
 
-	@Override
-	public Optional<Edge> getEdge(String edgeId) {
-		return Optional.ofNullable(this.edgeCache.getEdgeFromEdgeId(edgeId));
-	}
+        @Override
+        public Optional<Edge> getEdge(String edgeId) {
+                return Optional.ofNullable(this.getEdgeFromCacheOrDb(edgeId));
+        }
+
+        /**
+         * Gets an {@link MyEdge} from cache or reloads it from Postgres if it is not
+         * yet cached.
+         *
+         * @param edgeId the Edge-ID
+         * @return the {@link MyEdge} or {@code null} if not found
+         */
+        public MyEdge getEdgeFromCacheOrDb(String edgeId) {
+                var edge = this.edgeCache.getEdgeFromEdgeId(edgeId);
+                if (edge != null) {
+                        return edge;
+                }
+                if (this.postgresHandler != null) {
+                        try {
+                                return this.postgresHandler.edge.loadEdgeAndCache(this.edgeCache, edgeId).orElse(null);
+                        } catch (Exception e) {
+                                this.logWarn(this.log, "Unable to load Edge [" + edgeId + "] from Postgres: " + e.getMessage());
+                        }
+                }
+                return null;
+        }
 
 	@Override
 	public Optional<User> getUser(String userId) {
@@ -363,14 +385,16 @@ public class MetadataOdoo extends AbstractMetadata implements AppCenterMetadata,
 			this.postgresHandler.getPeriodicWriteWorker().onLastMessage(edge);
 		}
 
-		case Edge.Events.ON_SET_SUM_STATE -> {
-			var edgeId = reader.getString(Edge.Events.OnSetSumState.EDGE_ID);
-			var sumState = (Level) reader.getProperty(Edge.Events.OnSetSumState.SUM_STATE);
+               case Edge.Events.ON_SET_SUM_STATE -> {
+                       var edgeId = reader.getString(Edge.Events.OnSetSumState.EDGE_ID);
+                       var sumState = (Level) reader.getProperty(Edge.Events.OnSetSumState.SUM_STATE);
 
-			var edge = this.edgeCache.getEdgeFromEdgeId(edgeId);
-			// Set Sum-State in Odoo/Postgres
-			this.postgresHandler.getPeriodicWriteWorker().onSetSumState(edge, sumState);
-		}
+                        var edge = this.getEdgeFromCacheOrDb(edgeId);
+                        if (edge != null) {
+                                // Set Sum-State in Odoo/Postgres
+                                this.postgresHandler.getPeriodicWriteWorker().onSetSumState(edge, sumState);
+                        }
+                }
 
 		case Edge.Events.ON_SET_PRODUCTTYPE -> {
 			var edge = (MyEdge) reader.getProperty(Edge.Events.OnSetProducttype.EDGE);

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/odoo/OdooHandler.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/odoo/OdooHandler.java
@@ -422,11 +422,11 @@ public class OdooHandler {
 	 * @return the latest {@link SetupProtocolCoreInfo}
 	 * @throws OpenemsNamedException on error
 	 */
-	public SetupProtocolCoreInfo getLatestSetupProtocolCoreInfo(String edgeId) throws OpenemsNamedException {
-		final var edge = this.edgeCache.getEdgeFromEdgeId(edgeId);
-		if (edge == null) {
-			throw new OpenemsException("Edge not found for id [" + edgeId + "]");
-		}
+        public SetupProtocolCoreInfo getLatestSetupProtocolCoreInfo(String edgeId) throws OpenemsNamedException {
+                final var edge = this.parent.getEdgeFromCacheOrDb(edgeId);
+                if (edge == null) {
+                        throw new OpenemsException("Edge not found for id [" + edgeId + "]");
+                }
 
 		final var setupProtocolFilter = new Domain[] {
 				new Domain(Field.SetupProtocol.EDGE, Operator.EQ, edge.getOdooId()) };
@@ -456,11 +456,11 @@ public class OdooHandler {
 	 * @return the latest {@link SetupProtocolCoreInfo}
 	 * @throws OpenemsNamedException on error
 	 */
-	public List<SetupProtocolCoreInfo> getProtocolsCoreInfo(String edgeId) throws OpenemsNamedException {
-		final var edge = this.edgeCache.getEdgeFromEdgeId(edgeId);
-		if (edge == null) {
-			throw new OpenemsException("Edge not found for id [" + edgeId + "]");
-		}
+        public List<SetupProtocolCoreInfo> getProtocolsCoreInfo(String edgeId) throws OpenemsNamedException {
+                final var edge = this.parent.getEdgeFromCacheOrDb(edgeId);
+                if (edge == null) {
+                        throw new OpenemsException("Edge not found for id [" + edgeId + "]");
+                }
 
 		final var setupProtocolFilter = new Domain[] {
 				new Domain(Field.SetupProtocol.EDGE, Operator.EQ, edge.getOdooId()) };
@@ -578,12 +578,12 @@ public class OdooHandler {
 		OdooUtils.write(this.credentials, Field.EdgeDevice.ODOO_MODEL, new Integer[] { odooEdgeId },
 				new FieldValue<>(Field.EdgeDevice.COMMENT, comment));
 
-		// update edge cache
-		var edge = this.edgeCache.getEdgeFromEdgeId(edgeId);
-		if (edge != null) {
-			edge.setComment(comment);
-		}
-	}
+                // update edge cache
+                var edge = this.parent.getEdgeFromCacheOrDb(edgeId);
+                if (edge != null) {
+                        edge.setComment(comment);
+                }
+        }
 
 	/**
 	 * Call Odoo api to send mail via Odoo.

--- a/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/postgres/PgEdgeHandler.java
+++ b/io.openems.backend.metadata.odoo/src/io/openems/backend/metadata/odoo/postgres/PgEdgeHandler.java
@@ -5,15 +5,18 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.zaxxer.hikari.HikariDataSource;
 
 import io.openems.backend.common.metadata.Metadata.GenericSystemLog;
+import io.openems.backend.metadata.odoo.EdgeCache;
 import io.openems.backend.metadata.odoo.Field;
 import io.openems.backend.metadata.odoo.Field.EdgeConfigUpdate;
 import io.openems.backend.metadata.odoo.Field.EdgeDevice;
+import io.openems.backend.metadata.odoo.MyEdge;
 import io.openems.common.channel.Level;
 import io.openems.common.exceptions.OpenemsError.OpenemsNamedException;
 import io.openems.common.exceptions.OpenemsException;
@@ -38,7 +41,7 @@ public final class PgEdgeHandler {
 	 * @throws OpenemsNamedException on error
 	 * @throws SQLException          on error
 	 */
-	public EdgeConfig getEdgeConfig(String edgeId) throws SQLException, OpenemsNamedException {
+        public EdgeConfig getEdgeConfig(String edgeId) throws SQLException, OpenemsNamedException {
 		try (var con = this.dataSource.getConnection(); //
 				var pst = con.prepareStatement(new StringBuilder() //
 						.append("SELECT ").append(EdgeDevice.OPENEMS_CONFIG.id()) //
@@ -58,8 +61,37 @@ public final class PgEdgeHandler {
 				}
 			}
 		}
-		throw new OpenemsException("Unable to find EdgeConfig for [" + edgeId + "]");
-	}
+                throw new OpenemsException("Unable to find EdgeConfig for [" + edgeId + "]");
+        }
+
+        /**
+         * Loads an Edge from Postgres and updates the {@link EdgeCache}.
+         *
+         * @param edgeCache the {@link EdgeCache}
+         * @param edgeId    the Edge-ID
+         * @return the {@link MyEdge} if found; otherwise {@link Optional#empty()}
+         * @throws SQLException     on error
+         * @throws OpenemsException on error
+         */
+        public Optional<MyEdge> loadEdgeAndCache(EdgeCache edgeCache, String edgeId)
+                        throws SQLException, OpenemsException {
+                try (var con = this.dataSource.getConnection(); //
+                                var pst = con.prepareStatement(new StringBuilder() //
+                                                .append("SELECT ")
+                                                .append(Field.getSqlQueryFields(EdgeDevice.values())) //
+                                                .append(" FROM ").append(EdgeDevice.ODOO_TABLE) //
+                                                .append(" WHERE name = ?") //
+                                                .append(" LIMIT 1;") //
+                                                .toString())) {
+                        pst.setString(1, edgeId);
+                        try (var rs = pst.executeQuery()) {
+                                if (rs.next()) {
+                                        return Optional.of(edgeCache.addOrUpdate(rs));
+                                }
+                        }
+                }
+                return Optional.empty();
+        }
 
 	/**
 	 * Updates the {@link EdgeConfig} for an Edge-ID.


### PR DESCRIPTION
## Summary
- list Gitpod configuration files
- add docker-compose setup equivalent to Gitpod tasks
- ensure docker-compose services build and stay running by mirroring Gitpod init steps
- install gpg and expose JAVA_HOME in Gitpod Dockerfile
- document and include PostgreSQL service used by Odoo
- create matching `odoo`/`prod` database in Gitpod and run docker-compose services as root with repository working directories
- refresh edge cache from Postgres when an Edge is missing so new devices are discovered without restarting

## Testing
- `./gradlew :io.openems.backend.metadata.odoo:test :io.openems.common:test`
- `docker-compose -f docker-compose/docker-compose.yml config`


------
https://chatgpt.com/codex/tasks/task_e_68aa14268db083259fc4ef14e5ef4357